### PR TITLE
Fix root routing in vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,8 @@
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "api/index.py" },
-    { "src": "(.*)", "dest": "frontend/dist/threat-modeller/$1" }
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "frontend/dist/threat-modeller/index.html" }
   ],
   "env": {
     "GEMINI_API_KEY": "AIzaSyB-lF8abWV6zRcPZMEeFhogoIH-Uf_k8i4"


### PR DESCRIPTION
## Summary
- update `vercel.json` to send all non-api requests to Angular's built output

## Testing
- `npm test` *(fails: no test script defined)*
- `npm run build` *(fails: `ng` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f97db98788325bd4ce4316f036f0c